### PR TITLE
Mapbuilder QoL Update

### DIFF
--- a/.github/workflows/mapbuilder.yml
+++ b/.github/workflows/mapbuilder.yml
@@ -1,7 +1,9 @@
 name: mapbuilder
 run-name: Building maps for commit ${{ github.sha }} by ${{ github.actor }}
 on:
-  push
+  push:
+    paths:
+      - "mapdata/**"
   
 jobs:
   build-maps:


### PR DESCRIPTION
Only let mapbuilder run if the mapdata directory is changed because this can prevent stressing servers.